### PR TITLE
add textCombine002 to test adjacent textcombine spans

### DIFF
--- a/imsc1_1/ttml/textCombine/textCombine002.ttml
+++ b/imsc1_1/ttml/textCombine/textCombine002.ttml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tt xml:lang="ja"
+    xmlns:tt="http://www.w3.org/ns/ttml"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    xmlns="http://www.w3.org/ns/ttml"
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+    ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/imsc1.1/text">
+  <head>
+    <styling>
+      <style xml:id="s1"
+          tts:showBackground="whenActive"
+          tts:color="white"
+          tts:backgroundColor="black"
+          tts:textAlign="center"
+          tts:displayAlign="center"
+          tts:writingMode="tbrl"/>
+    </styling>
+    <layout>
+      <region style="s1"
+          xml:id="tbrlLeft"
+          tts:extent="10% 80%"
+          tts:position="left 20% center" />
+      <region style="s1"
+          xml:id="tbrlRight"
+          tts:extent="10% 80%"
+          tts:position="right 20% center" />
+    </layout>
+  </head>
+  <body>
+    <div begin="0s" end="1s">
+      <p region="tbrlLeft">あい<span tts:textCombine="none">AB34</span><span tts:textCombine="none">2nd</span>三四
+      </p>
+      <p region="tbrlRight">あい<span tts:textCombine="all">AB34</span><span tts:textCombine="all">2nd</span>三四
+      </p>
+    </div>
+  </body>
+</tt>


### PR DESCRIPTION
Introduces adjacent textCombine spans.
```
      <p region="tbrlLeft">あい<span tts:textCombine="none">AB34</span><span tts:textCombine="none">2nd</span>三四
      </p>
      <p region="tbrlRight">あい<span tts:textCombine="all">AB34</span><span tts:textCombine="all">2nd</span>三四
      </p>
```